### PR TITLE
GOCO-37: Use correct securityOpts to prevent nil pointer issue

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -164,7 +164,7 @@ func NewCluster(httpEndpoint string, credential Credential, opts ...*ClusterOpti
 		unmarshaler = NewJSONUnmarshaler()
 	}
 
-	if clusterOpts.SecurityOptions.DisableServerCertificateVerification != nil && *clusterOpts.SecurityOptions.DisableServerCertificateVerification {
+	if securityOpts.DisableServerCertificateVerification != nil && *securityOpts.DisableServerCertificateVerification {
 		logger.Warn("server certificate verification is disabled, this is insecure")
 	}
 


### PR DESCRIPTION
When creating a NewCluster with no securityOptions in the ClusterOptions you would get a Nil pointer dereference error.