### PR TITLE
GOCO-52: Update GHA dependencies & EA server build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.25'
       - run: |
           go install golang.org/x/tools/cmd/goimports@latest
       - name: goimports
@@ -31,7 +31,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11
+          version: v2.12
           args: --timeout=3m
-          skip-pkg-cache: true
-          skip-build-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Tag version
         id: tag_version
         run: |
@@ -31,7 +31,7 @@ jobs:
           echo $version
           echo "VERSION=$version" >> "$GITHUB_OUTPUT"
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ inputs.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Install cbdinocluster
         run: |
           mkdir -p "$HOME/bin"
-          wget -nv -O $HOME/bin/cbdinocluster https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.113/cbdinocluster-linux-amd64
-          chmod +x $HOME/bin/cbdinocluster
+          wget -nv -O "$HOME/bin/cbdinocluster" https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.118/cbdinocluster-linux-amd64
+          chmod +x "$HOME/bin/cbdinocluster"
           echo "$HOME/bin" >> $GITHUB_PATH
       - name: Install s3mock
         run: |
@@ -36,7 +36,7 @@ jobs:
             columnar: true
             nodes:
               - count: 3
-                version: 2.2.0-1166
+                version: 2.2.0-1314
             docker:
               load-balancer: true
               use-dino-certs: true
@@ -47,17 +47,15 @@ jobs:
           echo "CBDC_ID=$CBDC_ID" >> "$GITHUB_ENV"
           echo "CBDC_CONNSTR=$CBDC_CONNSTR" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.25'
       - name: Initialize deps
         run: go get
       - name: Run tests
         timeout-minutes: 40
         env:
-          CBDC_ID: # from above
-          CBDC_CONNSTR: # from above
           CBCONNSTR: ${{ env.CBDC_CONNSTR }}
         run: |
           go test ./... -v -race


### PR DESCRIPTION
## Changes

* Update version of third-party actions & bump Go version
* Update cbdinocluster version
* Update EA server build used for integration testing
* Remove some parameters/env variables that had no effect